### PR TITLE
Added Examples for PCL1.2 [Not Tested]

### DIFF
--- a/example-extract-indices/CMakeLists.txt
+++ b/example-extract-indices/CMakeLists.txt
@@ -1,0 +1,78 @@
+#############################################################################
+# KidTsunami - Professional. Live. Video.
+#
+# File:     CMakeLists.txt
+# Author:   Alexander Eichhorn <echa@kidtsunami.com>
+# Contents: Template CMake file libopenframeworks project
+#
+#
+# Copyright 2012 KidTsunami. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#############################################################################
+
+# minimum cmake version required
+cmake_minimum_required(VERSION 2.8)
+
+# give the project a name
+project (example_project)
+
+# Search for libopenframeworks package (will search for OFConfig.cmake,
+# of-config.cmake and FindOF.cmake) - we use of-config.cmake which gets
+# installed under CMAKE_INSTALL_PREFIX/lib/cmake/of.
+#
+# You MUST tell cmake where to search for the configuration, either by
+#
+#    cmake -DCMAKE_PREFIX_PATH=<openframeworks-install-path>/lib/cmake/of
+#
+# or by setting the environment variable OF_DIR to the above directory.
+#
+find_package(OF REQUIRED)
+include(FindPackageHandleStandardArgs)
+
+# set include directories
+include_directories (${OF_INCLUDES} ../SharedCode)
+
+# set cflags
+add_definitions (${OF_CFLAGS})
+
+# add link search directories
+link_directories (${OF_LIBRARY_DIRS})
+
+# define sources
+add_executable(${CMAKE_PROJECT_NAME}
+    src/main.cpp
+    src/testApp.cpp
+)
+
+# link target against libopenframeworks (and implicitly against all depending
+# 3rd-party libraries)
+target_link_libraries(${CMAKE_PROJECT_NAME} ${OF_LIBRARIES})
+
+# if applicable, set LDFLAGS
+if (OF_LDFLAGS)
+    set_target_properties(${target_name} PROPERTIES LINK_FLAGS ${OF_LDFLAGS})
+endif ()
+
+# soft-link shared data into build directory
+
+# make sure EXTRA_DATA_OUTPUT_DIRECTORY (without the last name part) exists
+#get_filename_component(_SHARE_PATH_BASE ${EXTRA_DATA_OUTPUT_DIRECTORY} PATH)
+
+# create base directory
+#file(MAKE_DIRECTORY ${_SHARE_PATH_BASE})
+
+# link shared/ from source tree to build tree
+execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+              ${CMAKE_SOURCE_DIR}/share ${CMAKE_BINARY_DIR}/share)

--- a/example-extract-indices/src/main.cpp
+++ b/example-extract-indices/src/main.cpp
@@ -1,0 +1,17 @@
+#include "ofMain.h"
+#include "testApp.h"
+#include "ofAppGlutWindow.h"
+
+//========================================================================
+int main( )
+{
+
+	ofAppGlutWindow window;
+	ofSetupOpenGL(&window, 1024, 768, OF_WINDOW);
+
+	// this kicks off the running of my app
+	// can be OF_WINDOW or OF_FULLSCREEN
+	// pass in width and height too:
+	ofRunApp(new testApp());
+
+}

--- a/example-extract-indices/src/testApp.cpp
+++ b/example-extract-indices/src/testApp.cpp
@@ -1,0 +1,110 @@
+// Example from http://pointclouds.org/documentation/tutorials/extract_indices.php
+
+#include <iostream>
+#include "testApp.h"
+
+//--------------------------------------------------------------
+void testApp::setup()
+{
+	ofxPCL::PointCloud cloud(new ofxPCL::PointCloud::value_type);
+	vector<ofxPCL::PointCloud> clouds;
+	
+	ofxPCL::loadPointCloud(string("table_scene_lms400.pcd"), cloud);
+		
+	std::cerr << "PointCloud before filtering: " << cloud->width * cloud->height 
+	<< " data points (" << pcl::getFieldsList (*cloud) << ")." << endl;
+	
+	ofxPCL::downsample(cloud, ofVec3f(0.01f, 0.01f, 0.01f));
+	
+	std::cerr << "PointCloud after filtering: " << cloud->width * cloud->height 
+	<< " data points (" << pcl::getFieldsList (*cloud) << ")." << endl;
+	
+	ofxPCL::savePointCloud("table_scene_lms400_inliers.pcd", cloud);
+	
+	clouds = ofxPCL::segmentation(cloud, pcl::SACMODEL_PLANE, 0.01, 10, 30);
+	
+	meshes.push_back(ofxPCL::toOF(cloud));
+	for( int i = 0; i < clouds.size(); i++ ) {
+		meshes.push_back(ofxPCL::toOF(clouds[i]));
+	}
+	mit = meshes.begin();
+}
+
+//--------------------------------------------------------------
+void testApp::update()
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::draw()
+{
+	ofBackground(0);
+	
+	cam.begin();
+	ofScale(100, 100, 100);
+	glEnable(GL_DEPTH_TEST);
+	
+	mit->drawVertices();
+	
+	cam.end();
+}
+
+//--------------------------------------------------------------
+void testApp::keyPressed(int key)
+{
+	if(key == ' ') {
+		advance(mit, 1);
+		if( mit == meshes.end() ) {
+			mit = meshes.begin();
+		}
+	}	
+}
+
+//--------------------------------------------------------------
+void testApp::keyReleased(int key)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::mouseMoved(int x, int y)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::mouseDragged(int x, int y, int button)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::mousePressed(int x, int y, int button)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::mouseReleased(int x, int y, int button)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::windowResized(int w, int h)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::gotMessage(ofMessage msg)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::dragEvent(ofDragInfo dragInfo)
+{
+	
+}

--- a/example-extract-indices/src/testApp.cpp
+++ b/example-extract-indices/src/testApp.cpp
@@ -9,7 +9,7 @@ void testApp::setup()
 	ofxPCL::PointCloud cloud(new ofxPCL::PointCloud::value_type);
 	vector<ofxPCL::PointCloud> clouds;
 	
-	ofxPCL::loadPointCloud(string("table_scene_lms400.pcd"), cloud);
+	cloud = ofxPCL::loadPointCloud(string("table_scene_lms400.pcd"));
 		
 	std::cerr << "PointCloud before filtering: " << cloud->width * cloud->height 
 	<< " data points (" << pcl::getFieldsList (*cloud) << ")." << endl;

--- a/example-extract-indices/src/testApp.h
+++ b/example-extract-indices/src/testApp.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#define nil Boost_nil
+#define Nil Boost_Nil
+#include "ofMain.h"
+#include "ofxPCL.h"
+#undef Nil
+#undef nil
+
+class testApp : public ofBaseApp
+{
+
+public:
+	void setup();
+	void update();
+	void draw();
+
+	void keyPressed(int key);
+	void keyReleased(int key);
+	void mouseMoved(int x, int y);
+	void mouseDragged(int x, int y, int button);
+	void mousePressed(int x, int y, int button);
+	void mouseReleased(int x, int y, int button);
+	void windowResized(int w, int h);
+	void dragEvent(ofDragInfo dragInfo);
+	void gotMessage(ofMessage msg);
+	
+	ofEasyCam cam;
+	vector<ofVboMesh> meshes;
+	vector<ofVboMesh>::iterator mit;
+};

--- a/example-greedy-projection/CMakeLists.txt
+++ b/example-greedy-projection/CMakeLists.txt
@@ -1,0 +1,78 @@
+#############################################################################
+# KidTsunami - Professional. Live. Video.
+#
+# File:     CMakeLists.txt
+# Author:   Alexander Eichhorn <echa@kidtsunami.com>
+# Contents: Template CMake file libopenframeworks project
+#
+#
+# Copyright 2012 KidTsunami. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#############################################################################
+
+# minimum cmake version required
+cmake_minimum_required(VERSION 2.8)
+
+# give the project a name
+project (example_project)
+
+# Search for libopenframeworks package (will search for OFConfig.cmake,
+# of-config.cmake and FindOF.cmake) - we use of-config.cmake which gets
+# installed under CMAKE_INSTALL_PREFIX/lib/cmake/of.
+#
+# You MUST tell cmake where to search for the configuration, either by
+#
+#    cmake -DCMAKE_PREFIX_PATH=<openframeworks-install-path>/lib/cmake/of
+#
+# or by setting the environment variable OF_DIR to the above directory.
+#
+find_package(OF REQUIRED)
+include(FindPackageHandleStandardArgs)
+
+# set include directories
+include_directories (${OF_INCLUDES} ../SharedCode)
+
+# set cflags
+add_definitions (${OF_CFLAGS})
+
+# add link search directories
+link_directories (${OF_LIBRARY_DIRS})
+
+# define sources
+add_executable(${CMAKE_PROJECT_NAME}
+    src/main.cpp
+    src/testApp.cpp
+)
+
+# link target against libopenframeworks (and implicitly against all depending
+# 3rd-party libraries)
+target_link_libraries(${CMAKE_PROJECT_NAME} ${OF_LIBRARIES})
+
+# if applicable, set LDFLAGS
+if (OF_LDFLAGS)
+    set_target_properties(${target_name} PROPERTIES LINK_FLAGS ${OF_LDFLAGS})
+endif ()
+
+# soft-link shared data into build directory
+
+# make sure EXTRA_DATA_OUTPUT_DIRECTORY (without the last name part) exists
+#get_filename_component(_SHARE_PATH_BASE ${EXTRA_DATA_OUTPUT_DIRECTORY} PATH)
+
+# create base directory
+#file(MAKE_DIRECTORY ${_SHARE_PATH_BASE})
+
+# link shared/ from source tree to build tree
+execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+              ${CMAKE_SOURCE_DIR}/share ${CMAKE_BINARY_DIR}/share)

--- a/example-greedy-projection/src/main.cpp
+++ b/example-greedy-projection/src/main.cpp
@@ -1,0 +1,17 @@
+#include "ofMain.h"
+#include "testApp.h"
+#include "ofAppGlutWindow.h"
+
+//========================================================================
+int main( )
+{
+
+	ofAppGlutWindow window;
+	ofSetupOpenGL(&window, 1024, 768, OF_WINDOW);
+
+	// this kicks off the running of my app
+	// can be OF_WINDOW or OF_FULLSCREEN
+	// pass in width and height too:
+	ofRunApp(new testApp());
+
+}

--- a/example-greedy-projection/src/testApp.cpp
+++ b/example-greedy-projection/src/testApp.cpp
@@ -1,0 +1,101 @@
+// Example from http://pointclouds.org/documentation/tutorials/greedy_projection.php
+
+#include <iostream>
+#include "testApp.h"
+
+//--------------------------------------------------------------
+void testApp::setup()
+{
+	dispRaw = false;
+	
+	ofxPCL::PointCloud cloud(new ofxPCL::PointCloud::value_type);
+	ofxPCL::PointNormalPointCloud cloud_with_normals(new ofxPCL::PointNormalPointCloud::value_type);
+	
+	ofxPCL::loadPointCloud("bun0.pcd", cloud);
+	
+	meshraw = ofxPCL::toOF(cloud);
+	
+	ofxPCL::normalEstimation(cloud, cloud_with_normals);
+
+	mesh = ofxPCL::triangulate(cloud_with_normals, 0.025);
+}
+
+//--------------------------------------------------------------
+void testApp::update()
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::draw()
+{
+	ofBackground(0);
+	
+	cam.begin();
+	ofScale(100, 100, 100);
+	glEnable(GL_DEPTH_TEST);
+	
+	if( dispRaw ) {
+		meshraw.drawVertices();
+	} else {
+		mesh.draw();
+	}
+	
+	cam.end();	
+}
+
+//--------------------------------------------------------------
+void testApp::keyPressed(int key)
+{
+	if(key == ' ') {
+		dispRaw = !dispRaw;
+	}
+}
+
+//--------------------------------------------------------------
+void testApp::keyReleased(int key)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::mouseMoved(int x, int y)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::mouseDragged(int x, int y, int button)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::mousePressed(int x, int y, int button)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::mouseReleased(int x, int y, int button)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::windowResized(int w, int h)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::gotMessage(ofMessage msg)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::dragEvent(ofDragInfo dragInfo)
+{
+	
+}

--- a/example-greedy-projection/src/testApp.cpp
+++ b/example-greedy-projection/src/testApp.cpp
@@ -11,7 +11,7 @@ void testApp::setup()
 	ofxPCL::PointCloud cloud(new ofxPCL::PointCloud::value_type);
 	ofxPCL::PointNormalPointCloud cloud_with_normals(new ofxPCL::PointNormalPointCloud::value_type);
 	
-	ofxPCL::loadPointCloud("bun0.pcd", cloud);
+	cloud = ofxPCL::loadPointCloud("bun0.pcd");
 	
 	meshraw = ofxPCL::toOF(cloud);
 	

--- a/example-greedy-projection/src/testApp.h
+++ b/example-greedy-projection/src/testApp.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#define nil Boost_nil
+#define Nil Boost_Nil
+#include "ofMain.h"
+#include "ofxPCL.h"
+#undef Nil
+#undef nil
+
+class testApp : public ofBaseApp
+{
+
+public:
+	void setup();
+	void update();
+	void draw();
+
+	void keyPressed(int key);
+	void keyReleased(int key);
+	void mouseMoved(int x, int y);
+	void mouseDragged(int x, int y, int button);
+	void mousePressed(int x, int y, int button);
+	void mouseReleased(int x, int y, int button);
+	void windowResized(int w, int h);
+	void dragEvent(ofDragInfo dragInfo);
+	void gotMessage(ofMessage msg);
+
+	ofEasyCam cam;
+	ofVboMesh mesh, meshraw;
+	bool dispRaw;
+};

--- a/example-resampling/CMakeLists.txt
+++ b/example-resampling/CMakeLists.txt
@@ -1,0 +1,78 @@
+#############################################################################
+# KidTsunami - Professional. Live. Video.
+#
+# File:     CMakeLists.txt
+# Author:   Alexander Eichhorn <echa@kidtsunami.com>
+# Contents: Template CMake file libopenframeworks project
+#
+#
+# Copyright 2012 KidTsunami. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#############################################################################
+
+# minimum cmake version required
+cmake_minimum_required(VERSION 2.8)
+
+# give the project a name
+project (example_project)
+
+# Search for libopenframeworks package (will search for OFConfig.cmake,
+# of-config.cmake and FindOF.cmake) - we use of-config.cmake which gets
+# installed under CMAKE_INSTALL_PREFIX/lib/cmake/of.
+#
+# You MUST tell cmake where to search for the configuration, either by
+#
+#    cmake -DCMAKE_PREFIX_PATH=<openframeworks-install-path>/lib/cmake/of
+#
+# or by setting the environment variable OF_DIR to the above directory.
+#
+find_package(OF REQUIRED)
+include(FindPackageHandleStandardArgs)
+
+# set include directories
+include_directories (${OF_INCLUDES} ../SharedCode)
+
+# set cflags
+add_definitions (${OF_CFLAGS})
+
+# add link search directories
+link_directories (${OF_LIBRARY_DIRS})
+
+# define sources
+add_executable(${CMAKE_PROJECT_NAME}
+    src/main.cpp
+    src/testApp.cpp
+)
+
+# link target against libopenframeworks (and implicitly against all depending
+# 3rd-party libraries)
+target_link_libraries(${CMAKE_PROJECT_NAME} ${OF_LIBRARIES})
+
+# if applicable, set LDFLAGS
+if (OF_LDFLAGS)
+    set_target_properties(${target_name} PROPERTIES LINK_FLAGS ${OF_LDFLAGS})
+endif ()
+
+# soft-link shared data into build directory
+
+# make sure EXTRA_DATA_OUTPUT_DIRECTORY (without the last name part) exists
+#get_filename_component(_SHARE_PATH_BASE ${EXTRA_DATA_OUTPUT_DIRECTORY} PATH)
+
+# create base directory
+#file(MAKE_DIRECTORY ${_SHARE_PATH_BASE})
+
+# link shared/ from source tree to build tree
+execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+              ${CMAKE_SOURCE_DIR}/share ${CMAKE_BINARY_DIR}/share)

--- a/example-resampling/src/main.cpp
+++ b/example-resampling/src/main.cpp
@@ -1,0 +1,17 @@
+#include "ofMain.h"
+#include "testApp.h"
+#include "ofAppGlutWindow.h"
+
+//========================================================================
+int main( )
+{
+
+	ofAppGlutWindow window;
+	ofSetupOpenGL(&window, 1024, 768, OF_WINDOW);
+
+	// this kicks off the running of my app
+	// can be OF_WINDOW or OF_FULLSCREEN
+	// pass in width and height too:
+	ofRunApp(new testApp());
+
+}

--- a/example-resampling/src/testApp.cpp
+++ b/example-resampling/src/testApp.cpp
@@ -1,0 +1,101 @@
+// Example from http://pointclouds.org/documentation/tutorials/resampling.php
+
+#include <iostream>
+#include "testApp.h"
+
+//--------------------------------------------------------------
+void testApp::setup()
+{
+	dispRaw = false;
+	
+	ofxPCL::PointCloud cloud(new ofxPCL::PointCloud::value_type);
+	ofxPCL::PointNormalPointCloud mls_points(new ofxPCL::PointNormalPointCloud::value_type);
+
+	ofxPCL::loadPointCloud("bun0.pcd", cloud);
+	
+	meshraw = ofxPCL::toOF(cloud);
+	
+	ofxPCL::movingLeastSquares(cloud, mls_points, 0.03);
+	
+	mesh = ofxPCL::toOF(mls_points);
+}
+
+//--------------------------------------------------------------
+void testApp::update()
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::draw()
+{
+	ofBackground(0);
+	
+	cam.begin();
+	ofScale(1000, 1000, 1000);
+	glEnable(GL_DEPTH_TEST);
+	
+	if( dispRaw ) {
+		meshraw.drawVertices();
+	} else {
+		mesh.drawVertices();
+	}
+	
+	cam.end();	
+}
+
+//--------------------------------------------------------------
+void testApp::keyPressed(int key)
+{
+	if(key == ' ') {
+		dispRaw = !dispRaw;
+	}
+}
+
+//--------------------------------------------------------------
+void testApp::keyReleased(int key)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::mouseMoved(int x, int y)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::mouseDragged(int x, int y, int button)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::mousePressed(int x, int y, int button)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::mouseReleased(int x, int y, int button)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::windowResized(int w, int h)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::gotMessage(ofMessage msg)
+{
+	
+}
+
+//--------------------------------------------------------------
+void testApp::dragEvent(ofDragInfo dragInfo)
+{
+	
+}

--- a/example-resampling/src/testApp.cpp
+++ b/example-resampling/src/testApp.cpp
@@ -11,7 +11,7 @@ void testApp::setup()
 	ofxPCL::PointCloud cloud(new ofxPCL::PointCloud::value_type);
 	ofxPCL::PointNormalPointCloud mls_points(new ofxPCL::PointNormalPointCloud::value_type);
 
-	ofxPCL::loadPointCloud("bun0.pcd", cloud);
+	cloud = ofxPCL::loadPointCloud("bun0.pcd");
 	
 	meshraw = ofxPCL::toOF(cloud);
 	

--- a/example-resampling/src/testApp.h
+++ b/example-resampling/src/testApp.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#define nil Boost_nil
+#define Nil Boost_Nil
+#include "ofMain.h"
+#include "ofxPCL.h"
+#undef Nil
+#undef nil
+
+class testApp : public ofBaseApp
+{
+
+public:
+	void setup();
+	void update();
+	void draw();
+
+	void keyPressed(int key);
+	void keyReleased(int key);
+	void mouseMoved(int x, int y);
+	void mouseDragged(int x, int y, int button);
+	void mousePressed(int x, int y, int button);
+	void mouseReleased(int x, int y, int button);
+	void windowResized(int w, int h);
+	void dragEvent(ofDragInfo dragInfo);
+	void gotMessage(ofMessage msg);
+	
+	ofEasyCam cam;
+	ofVboMesh mesh, meshraw;
+	bool dispRaw;
+};

--- a/example-statistical-removal/CMakeLists.txt
+++ b/example-statistical-removal/CMakeLists.txt
@@ -1,0 +1,78 @@
+#############################################################################
+# KidTsunami - Professional. Live. Video.
+#
+# File:     CMakeLists.txt
+# Author:   Alexander Eichhorn <echa@kidtsunami.com>
+# Contents: Template CMake file libopenframeworks project
+#
+#
+# Copyright 2012 KidTsunami. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#############################################################################
+
+# minimum cmake version required
+cmake_minimum_required(VERSION 2.8)
+
+# give the project a name
+project (example_project)
+
+# Search for libopenframeworks package (will search for OFConfig.cmake,
+# of-config.cmake and FindOF.cmake) - we use of-config.cmake which gets
+# installed under CMAKE_INSTALL_PREFIX/lib/cmake/of.
+#
+# You MUST tell cmake where to search for the configuration, either by
+#
+#    cmake -DCMAKE_PREFIX_PATH=<openframeworks-install-path>/lib/cmake/of
+#
+# or by setting the environment variable OF_DIR to the above directory.
+#
+find_package(OF REQUIRED)
+include(FindPackageHandleStandardArgs)
+
+# set include directories
+include_directories (${OF_INCLUDES} ../SharedCode)
+
+# set cflags
+add_definitions (${OF_CFLAGS})
+
+# add link search directories
+link_directories (${OF_LIBRARY_DIRS})
+
+# define sources
+add_executable(${CMAKE_PROJECT_NAME}
+    src/main.cpp
+    src/testApp.cpp
+)
+
+# link target against libopenframeworks (and implicitly against all depending
+# 3rd-party libraries)
+target_link_libraries(${CMAKE_PROJECT_NAME} ${OF_LIBRARIES})
+
+# if applicable, set LDFLAGS
+if (OF_LDFLAGS)
+    set_target_properties(${target_name} PROPERTIES LINK_FLAGS ${OF_LDFLAGS})
+endif ()
+
+# soft-link shared data into build directory
+
+# make sure EXTRA_DATA_OUTPUT_DIRECTORY (without the last name part) exists
+#get_filename_component(_SHARE_PATH_BASE ${EXTRA_DATA_OUTPUT_DIRECTORY} PATH)
+
+# create base directory
+#file(MAKE_DIRECTORY ${_SHARE_PATH_BASE})
+
+# link shared/ from source tree to build tree
+execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+              ${CMAKE_SOURCE_DIR}/share ${CMAKE_BINARY_DIR}/share)

--- a/example-statistical-removal/src/main.cpp
+++ b/example-statistical-removal/src/main.cpp
@@ -1,0 +1,17 @@
+#include "ofMain.h"
+#include "testApp.h"
+#include "ofAppGlutWindow.h"
+
+//========================================================================
+int main( )
+{
+
+	ofAppGlutWindow window;
+	ofSetupOpenGL(&window, 1024, 768, OF_WINDOW);
+
+	// this kicks off the running of my app
+	// can be OF_WINDOW or OF_FULLSCREEN
+	// pass in width and height too:
+	ofRunApp(new testApp());
+
+}

--- a/example-statistical-removal/src/testApp.cpp
+++ b/example-statistical-removal/src/testApp.cpp
@@ -1,0 +1,108 @@
+// Example from http://pointclouds.org/documentation/tutorials/statistical_outlier.php
+
+#include <iostream>
+#include "testApp.h"
+
+//--------------------------------------------------------------
+void testApp::setup()
+{
+	dispRaw = false;
+	
+	ofxPCL::PointCloud cloud(new ofxPCL::PointCloud::value_type);
+	
+	ofxPCL::loadPointCloud(string("table_scene_lms400.pcd"), cloud);
+	
+	meshraw = ofxPCL::toOF(cloud);
+	
+	std::cerr << "PointCloud before filtering: " << cloud->width * cloud->height 
+	<< " data points (" << pcl::getFieldsList (*cloud) << ")." << endl;
+	
+	ofxPCL::statisticalOutlierRemoval(cloud, 50, 1.0);
+	
+	std::cerr << "PointCloud after filtering: " << cloud->width * cloud->height 
+	<< " data points (" << pcl::getFieldsList (*cloud) << ")." << endl;
+	
+	ofxPCL::savePointCloud("table_scene_lms400_inliers.pcd", cloud);
+	
+	mesh = ofxPCL::toOF(cloud);
+}
+
+//--------------------------------------------------------------
+void testApp::update()
+{
+
+}
+
+//--------------------------------------------------------------
+void testApp::draw()
+{
+	ofBackground(0);
+	
+	cam.begin();
+	ofScale(100, 100, 100);
+	glEnable(GL_DEPTH_TEST);
+	
+	if( dispRaw ) {
+		meshraw.drawVertices();
+	} else {
+		mesh.drawVertices();
+	}
+	
+	cam.end();
+}
+
+//--------------------------------------------------------------
+void testApp::keyPressed(int key)
+{
+	if(key == ' ') {
+		dispRaw = !dispRaw;
+	}	
+}
+
+//--------------------------------------------------------------
+void testApp::keyReleased(int key)
+{
+
+}
+
+//--------------------------------------------------------------
+void testApp::mouseMoved(int x, int y)
+{
+
+}
+
+//--------------------------------------------------------------
+void testApp::mouseDragged(int x, int y, int button)
+{
+
+}
+
+//--------------------------------------------------------------
+void testApp::mousePressed(int x, int y, int button)
+{
+
+}
+
+//--------------------------------------------------------------
+void testApp::mouseReleased(int x, int y, int button)
+{
+
+}
+
+//--------------------------------------------------------------
+void testApp::windowResized(int w, int h)
+{
+
+}
+
+//--------------------------------------------------------------
+void testApp::gotMessage(ofMessage msg)
+{
+
+}
+
+//--------------------------------------------------------------
+void testApp::dragEvent(ofDragInfo dragInfo)
+{
+
+}

--- a/example-statistical-removal/src/testApp.cpp
+++ b/example-statistical-removal/src/testApp.cpp
@@ -10,7 +10,7 @@ void testApp::setup()
 	
 	ofxPCL::PointCloud cloud(new ofxPCL::PointCloud::value_type);
 	
-	ofxPCL::loadPointCloud(string("table_scene_lms400.pcd"), cloud);
+	cloud = ofxPCL::loadPointCloud(string("table_scene_lms400.pcd"));
 	
 	meshraw = ofxPCL::toOF(cloud);
 	

--- a/example-statistical-removal/src/testApp.h
+++ b/example-statistical-removal/src/testApp.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#define nil Boost_nil
+#define Nil Boost_Nil
+#include "ofMain.h"
+#include "ofxPCL.h"
+#undef Nil
+#undef nil
+
+class testApp : public ofBaseApp
+{
+
+public:
+	void setup();
+	void update();
+	void draw();
+
+	void keyPressed(int key);
+	void keyReleased(int key);
+	void mouseMoved(int x, int y);
+	void mouseDragged(int x, int y, int button);
+	void mousePressed(int x, int y, int button);
+	void mouseReleased(int x, int y, int button);
+	void windowResized(int w, int h);
+	void dragEvent(ofDragInfo dragInfo);
+	void gotMessage(ofMessage msg);
+	
+	ofEasyCam cam;
+	ofVboMesh mesh, meshraw;
+	bool dispRaw;
+};

--- a/example-voxel-grid/CMakeLists.txt
+++ b/example-voxel-grid/CMakeLists.txt
@@ -1,0 +1,78 @@
+#############################################################################
+# KidTsunami - Professional. Live. Video.
+#
+# File:     CMakeLists.txt
+# Author:   Alexander Eichhorn <echa@kidtsunami.com>
+# Contents: Template CMake file libopenframeworks project
+#
+#
+# Copyright 2012 KidTsunami. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#############################################################################
+
+# minimum cmake version required
+cmake_minimum_required(VERSION 2.8)
+
+# give the project a name
+project (example_project)
+
+# Search for libopenframeworks package (will search for OFConfig.cmake,
+# of-config.cmake and FindOF.cmake) - we use of-config.cmake which gets
+# installed under CMAKE_INSTALL_PREFIX/lib/cmake/of.
+#
+# You MUST tell cmake where to search for the configuration, either by
+#
+#    cmake -DCMAKE_PREFIX_PATH=<openframeworks-install-path>/lib/cmake/of
+#
+# or by setting the environment variable OF_DIR to the above directory.
+#
+find_package(OF REQUIRED)
+include(FindPackageHandleStandardArgs)
+
+# set include directories
+include_directories (${OF_INCLUDES} ../SharedCode)
+
+# set cflags
+add_definitions (${OF_CFLAGS})
+
+# add link search directories
+link_directories (${OF_LIBRARY_DIRS})
+
+# define sources
+add_executable(${CMAKE_PROJECT_NAME}
+    src/main.cpp
+    src/testApp.cpp
+)
+
+# link target against libopenframeworks (and implicitly against all depending
+# 3rd-party libraries)
+target_link_libraries(${CMAKE_PROJECT_NAME} ${OF_LIBRARIES})
+
+# if applicable, set LDFLAGS
+if (OF_LDFLAGS)
+    set_target_properties(${target_name} PROPERTIES LINK_FLAGS ${OF_LDFLAGS})
+endif ()
+
+# soft-link shared data into build directory
+
+# make sure EXTRA_DATA_OUTPUT_DIRECTORY (without the last name part) exists
+#get_filename_component(_SHARE_PATH_BASE ${EXTRA_DATA_OUTPUT_DIRECTORY} PATH)
+
+# create base directory
+#file(MAKE_DIRECTORY ${_SHARE_PATH_BASE})
+
+# link shared/ from source tree to build tree
+execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+              ${CMAKE_SOURCE_DIR}/share ${CMAKE_BINARY_DIR}/share)

--- a/example-voxel-grid/src/main.cpp
+++ b/example-voxel-grid/src/main.cpp
@@ -1,0 +1,17 @@
+#include "ofMain.h"
+#include "testApp.h"
+#include "ofAppGlutWindow.h"
+
+//========================================================================
+int main( )
+{
+
+	ofAppGlutWindow window;
+	ofSetupOpenGL(&window, 1024, 768, OF_WINDOW);
+
+	// this kicks off the running of my app
+	// can be OF_WINDOW or OF_FULLSCREEN
+	// pass in width and height too:
+	ofRunApp(new testApp());
+
+}

--- a/example-voxel-grid/src/testApp.cpp
+++ b/example-voxel-grid/src/testApp.cpp
@@ -1,0 +1,108 @@
+// Example from http://pointclouds.org/documentation/tutorials/voxel_grid.php
+
+#include <iostream>
+#include "testApp.h"
+
+//--------------------------------------------------------------
+void testApp::setup()
+{
+	dispRaw = false;
+	
+	ofxPCL::PointCloud cloud(new ofxPCL::PointCloud::value_type);
+	
+	ofxPCL::loadPointCloud(string("table_scene_lms400.pcd"), cloud);
+	
+	meshraw = ofxPCL::toOF(cloud);
+	
+	std::cerr << "PointCloud before filtering: " << cloud->width * cloud->height 
+	<< " data points (" << pcl::getFieldsList (*cloud) << ")." << endl;
+	
+	ofxPCL::downsample(cloud, ofVec3f(0.01f, 0.01f, 0.01f));
+	
+	std::cerr << "PointCloud after filtering: " << cloud->width * cloud->height 
+	<< " data points (" << pcl::getFieldsList (*cloud) << ")." << endl;
+	
+	ofxPCL::savePointCloud("table_scene_lms400_downsampled.pcd", cloud);
+	
+	mesh = ofxPCL::toOF(cloud);
+}
+
+//--------------------------------------------------------------
+void testApp::update()
+{
+
+}
+
+//--------------------------------------------------------------
+void testApp::draw()
+{
+	ofBackground(0);
+	
+	cam.begin();
+	ofScale(100, 100, 100);
+	glEnable(GL_DEPTH_TEST);
+	
+	if( dispRaw ) {
+		meshraw.drawVertices();
+	} else {
+		mesh.drawVertices();
+	}
+	
+	cam.end();	
+}
+
+//--------------------------------------------------------------
+void testApp::keyPressed(int key)
+{
+	if(key == ' ') {
+		dispRaw = !dispRaw;
+	}
+}
+
+//--------------------------------------------------------------
+void testApp::keyReleased(int key)
+{
+
+}
+
+//--------------------------------------------------------------
+void testApp::mouseMoved(int x, int y)
+{
+
+}
+
+//--------------------------------------------------------------
+void testApp::mouseDragged(int x, int y, int button)
+{
+
+}
+
+//--------------------------------------------------------------
+void testApp::mousePressed(int x, int y, int button)
+{
+
+}
+
+//--------------------------------------------------------------
+void testApp::mouseReleased(int x, int y, int button)
+{
+
+}
+
+//--------------------------------------------------------------
+void testApp::windowResized(int w, int h)
+{
+
+}
+
+//--------------------------------------------------------------
+void testApp::gotMessage(ofMessage msg)
+{
+
+}
+
+//--------------------------------------------------------------
+void testApp::dragEvent(ofDragInfo dragInfo)
+{
+
+}

--- a/example-voxel-grid/src/testApp.cpp
+++ b/example-voxel-grid/src/testApp.cpp
@@ -10,7 +10,7 @@ void testApp::setup()
 	
 	ofxPCL::PointCloud cloud(new ofxPCL::PointCloud::value_type);
 	
-	ofxPCL::loadPointCloud(string("table_scene_lms400.pcd"), cloud);
+	cloud = ofxPCL::loadPointCloud(string("table_scene_lms400.pcd"));
 	
 	meshraw = ofxPCL::toOF(cloud);
 	

--- a/example-voxel-grid/src/testApp.h
+++ b/example-voxel-grid/src/testApp.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#define nil Boost_nil
+#define Nil Boost_Nil
+#include "ofMain.h"
+#include "ofxPCL.h"
+#undef Nil
+#undef nil
+
+class testApp : public ofBaseApp
+{
+
+public:
+	void setup();
+	void update();
+	void draw();
+
+	void keyPressed(int key);
+	void keyReleased(int key);
+	void mouseMoved(int x, int y);
+	void mouseDragged(int x, int y, int button);
+	void mousePressed(int x, int y, int button);
+	void mouseReleased(int x, int y, int button);
+	void windowResized(int w, int h);
+	void dragEvent(ofDragInfo dragInfo);
+	void gotMessage(ofMessage msg);
+
+	ofEasyCam cam;
+	ofVboMesh mesh, meshraw;
+	bool dispRaw;
+};

--- a/src/Utility.h
+++ b/src/Utility.h
@@ -46,6 +46,25 @@ inline void convert(const ColorPointCloud& cloud, ofMesh& mesh)
 		mesh.setVertex(i, ofVec3f(p.x, p.y, p.z));
 	}
 }
+	
+template <>
+inline void convert(const PointNormalPointCloud& cloud, ofMesh& mesh)
+{
+	assert(cloud);
+	
+	float inv_byte = 1. / 255.;
+	const size_t num_point = cloud->points.size();
+	
+	if (mesh.getNumVertices() != num_point) mesh.getVertices().resize(num_point);
+	if (mesh.getNumNormals() != num_point) mesh.getNormals().resize(num_point);
+	
+	for (int i = 0; i < num_point; i++)
+	{
+		PointNormalType &p = cloud->points[i];
+		mesh.setNormal(i, ofVec3f(p.normal_x, p.normal_y, p.normal_z));
+		mesh.setVertex(i, ofVec3f(p.x, p.y, p.z));
+	}
+}	
 
 template <>
 inline void convert(const ColorNormalPointCloud& cloud, ofMesh& mesh)

--- a/src/ofxPCL.h
+++ b/src/ofxPCL.h
@@ -232,7 +232,7 @@ void movingLeastSquares(const T1 &cloud, T2 &output_cloud_with_normals, float se
 
 	pcl::PointCloud<typename T1::value_type::PointType> mls_points;
 	NormalPointCloud mls_normals(new NormalPointCloud::value_type);
-	pcl::MovingLeastSquares<ColorPointType, NormalType> mls;
+	pcl::MovingLeastSquares<T1::value_type::PointType, NormalType> mls;
 
 	KdTree<typename T1::value_type::PointType> kdtree(cloud);
 


### PR DESCRIPTION
Ported examples from http://pointclouds.org/documentation/tutorials/.

However, these examples are only tested on PCL 1.6 + [libopenframeworks](https://github.com/echa/libopenframeworks) and not tested on ofxPCL(PCL 1.2) + native openFrameworks. The reason is that I am not familiar with Xcode and unfortunately, I cannot currently build native openFrameworks project with ofxBoost+ofxPCL on my OS X 10.6. Therefore, there are no Xcode project files, but I assume that they can be build with Xcode project file of example-empty since I didn't edit any header files in `src/` (except a bug in movingLeastSquares).

Also be careful that these examples require either http://svn.pointclouds.org/data/tutorials/table_scene_lms400.pcd or https://code.ros.org/trac/ros-pkg/export/34074/stacks/point_cloud_perception/trunk/pcl/test/bun0.pcd to be placed under `data/` folder.

Finally, I'm sorry that I branched examplePCL1.2 from master but sending pull request to develop.

Naoto
